### PR TITLE
Add SFTP stress testing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# sftptester
+# SFTP Tester
+
+This project provides a simple Python utility to stress test an SFTP server.
+It generates random zip files, uploads them to the server and removes them,
+collecting timing statistics for each file.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `config.yml.example` to `config.yml` and edit the values to match
+   your SFTP server.
+3. Run the tester:
+   ```bash
+   python sftp_tester.py --config config.yml
+   ```
+4. A report named `sftp_report_<timestamp>.txt` will be generated with
+   statistics for each file transfer.
+
+The script is cross-platform and relies on the `paramiko` library.

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,0 +1,15 @@
+# Example configuration for sftp_tester
+host: "192.168.0.1"
+username: "sftpuserid"
+root_dir: "/"
+ssh_private_key_passphrase: "privatekeypassphrase"
+ssh_private_key_path: "/path/to/privatekey"
+min_test_file_size_bytes: 6000
+max_test_file_size_bytes: 64000000
+num_test_files: 1
+connect_timeout_seconds: 20
+transfer_timeout_seconds: 20
+sftp_threads: 1
+sftp_sleep_interval: -1
+keep_alive_enabled: 0
+retry_attempts: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+paramiko>=3.5.1
+pyyaml>=6.0

--- a/sftp_config.py
+++ b/sftp_config.py
@@ -1,0 +1,72 @@
+import yaml
+
+
+class SFTPConfig:
+    def __init__(self):
+        self.host = None
+        self.username = None
+        self.root_dir = '/'
+        self.ssh_private_key_passphrase = None
+        self.ssh_private_key_path = None
+        self.min_test_file_size_bytes = 6000
+        self.max_test_file_size_bytes = 64000000
+        self.num_test_files = 1
+        self.connect_timeout_seconds = 20
+        self.transfer_timeout_seconds = 20
+        self.sftp_threads = 1
+        self.sftp_sleep_interval = -1
+        self.keep_alive_enabled = 0
+        self.retry_attempts = 0
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "SFTPConfig":
+        """Load configuration values from a YAML file."""
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+        cfg = cls()
+        for key, value in data.items():
+            if hasattr(cfg, key):
+                setattr(cfg, key, value)
+        return cfg
+
+    def setHost(self, host: str):
+        self.host = host
+
+    def setUserName(self, username: str):
+        self.username = username
+
+    def setRootDir(self, root: str):
+        self.root_dir = root
+
+    def setSshPrivateKeyPassPhrase(self, phrase: str):
+        self.ssh_private_key_passphrase = phrase
+
+    def setSshPrivateKeyPath(self, path: str):
+        self.ssh_private_key_path = path
+
+    def minTestFileSizeBytes(self, size: int):
+        self.min_test_file_size_bytes = int(size)
+
+    def maxTestFileSizeBytes(self, size: int):
+        self.max_test_file_size_bytes = int(size)
+
+    def numTestFiles(self, num: int):
+        self.num_test_files = int(num)
+
+    def ConnectTimeoutSeconds(self, timeout: int):
+        self.connect_timeout_seconds = int(timeout)
+
+    def TransferTimeoutSeconds(self, timeout: int):
+        self.transfer_timeout_seconds = int(timeout)
+
+    def sftpThreads(self, threads: int):
+        self.sftp_threads = int(threads)
+
+    def sftpSleepInterval(self, interval: int):
+        self.sftp_sleep_interval = int(interval)
+
+    def keepAliveEnabled(self, enabled: int):
+        self.keep_alive_enabled = int(enabled)
+
+    def retryAttempts(self, attempts: int):
+        self.retry_attempts = int(attempts)

--- a/sftp_tester.py
+++ b/sftp_tester.py
@@ -1,0 +1,160 @@
+import argparse
+import os
+import random
+import tempfile
+import time
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import paramiko
+
+from sftp_config import SFTPConfig
+
+@dataclass
+class FileStat:
+    name: str
+    size: int
+    connect_time: float
+    transfer_time: float
+    success: bool
+    error: Optional[str] = None
+
+@dataclass
+class TestReport:
+    file_stats: List[FileStat] = field(default_factory=list)
+
+    def add(self, stat: FileStat):
+        self.file_stats.append(stat)
+
+    def to_text(self) -> str:
+        lines = ["SFTP Test Report", "================="]
+        for stat in self.file_stats:
+            lines.append(
+                f"File: {stat.name} Size: {stat.size} bytes Success: {stat.success}"\
+                f" ConnectTime: {stat.connect_time:.2f}s TransferTime: {stat.transfer_time:.2f}s"\
+                + (f" Error: {stat.error}" if stat.error else "")
+            )
+        return "\n".join(lines)
+
+
+def create_random_zip(destination: str, size: int) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_path = os.path.join(tmpdir, "data.bin")
+        with open(data_path, "wb") as f:
+            f.write(os.urandom(size))
+        with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.write(data_path, arcname="data.bin")
+
+
+def _create_client(config: SFTPConfig) -> paramiko.SSHClient:
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        hostname=config.host,
+        username=config.username,
+        key_filename=config.ssh_private_key_path,
+        passphrase=config.ssh_private_key_passphrase,
+        timeout=None if config.connect_timeout_seconds == -1 else config.connect_timeout_seconds,
+    )
+    return client
+
+
+def sftp_operation(
+    config: SFTPConfig,
+    local_path: str,
+    remote_name: str,
+    client: Optional[paramiko.SSHClient] = None,
+) -> FileStat:
+    file_size = os.path.getsize(local_path)
+    if client is None:
+        start_conn = time.monotonic()
+        try:
+            client = _create_client(config)
+            connect_time = time.monotonic() - start_conn
+        except Exception as e:
+            return FileStat(remote_name, file_size, time.monotonic() - start_conn, 0, False, str(e))
+    else:
+        connect_time = 0.0
+
+    sftp = client.open_sftp()
+    start_transfer = time.monotonic()
+    try:
+        sftp.put(local_path, os.path.join(config.root_dir, remote_name))
+        sftp.remove(os.path.join(config.root_dir, remote_name))
+        success = True
+        error = None
+    except Exception as e:
+        success = False
+        error = str(e)
+    transfer_time = time.monotonic() - start_transfer
+    sftp.close()
+    if not config.keep_alive_enabled:
+        client.close()
+    if config.sftp_sleep_interval > 0:
+        time.sleep(config.sftp_sleep_interval)
+    return FileStat(remote_name, file_size, connect_time, transfer_time, success, error)
+
+
+def run_tests(config: SFTPConfig) -> TestReport:
+    temp_dir = tempfile.mkdtemp()
+    report = TestReport()
+    paths = []
+    try:
+        for i in range(config.num_test_files):
+            size = random.randint(config.min_test_file_size_bytes, config.max_test_file_size_bytes)
+            local_path = os.path.join(temp_dir, f"test_{i}.zip")
+            create_random_zip(local_path, size)
+            paths.append((local_path, f"test_{i}.zip"))
+        max_workers = config.sftp_threads if config.sftp_threads > 0 else os.cpu_count()
+        if config.keep_alive_enabled:
+            clients = [_create_client(config) for _ in range(max_workers)]
+        else:
+            clients = [None] * max_workers
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+            for idx, (path, name) in enumerate(paths):
+                client = clients[idx % max_workers]
+                futures.append(
+                    executor.submit(sftp_operation, config, path, name, client)
+                )
+            for future in futures:
+                report.add(future.result())
+
+        if config.keep_alive_enabled:
+            for c in clients:
+                c.close()
+    finally:
+        for path, _ in paths:
+            if os.path.exists(path):
+                os.remove(path)
+        os.rmdir(temp_dir)
+    return report
+
+
+def save_report(report: TestReport, filename: str) -> None:
+    with open(filename, "w") as f:
+        f.write(report.to_text())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run SFTP stress tests")
+    parser.add_argument(
+        "--config",
+        default="config.yml",
+        help="Path to YAML configuration file (default: config.yml)",
+    )
+    args = parser.parse_args()
+
+    config = SFTPConfig.from_yaml(args.config)
+
+    report = run_tests(config)
+    filename = f"sftp_report_{int(time.time())}.txt"
+    save_report(report, filename)
+    print(f"Report saved to {filename}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add sftp configuration helper
- implement tester for generating random files and uploading them via SFTP
- document usage
- add dependency on paramiko
- add config.yml support

## Testing
- `python -m py_compile sftp_config.py sftp_tester.py`
- `pip install -r requirements.txt`
- `python sftp_tester.py --config config.yml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685d8c5fa15c8328ab62857e4d2a8e71