### PR TITLE
Add progress bar and error logging for SFTP test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paramiko>=3.5.1
 pyyaml>=6.0
+tqdm>=4.66.2


### PR DESCRIPTION
## Summary
- log transfer errors to stderr
- show progress bars using tqdm during uploads
- add tqdm to requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile sftp_tester.py`
- `python sftp_tester.py --config config.yml.example` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685d9f1824bc8328b61a6d655965d0e1